### PR TITLE
Fix syntax error after string value support and parse floats

### DIFF
--- a/public/js/historian/historianGraph.js
+++ b/public/js/historian/historianGraph.js
@@ -128,9 +128,9 @@ var HistorianGraph = function(){
 					seriesData[key].data[counter].y = data[i].evt[j];
 				
 					key++;
-				} else (typeof data[i].evt[j] === 'string') {
+				} else if (typeof data[i].evt[j] == 'string') {
 					if(!isNaN(data[i].evt[j])) {
-						var value = parseInt(data[i].evt[j]);
+						var value = parseFloat(data[i].evt[j]);
 						if(i===data.length-1){
 							seriesData[key]={};
 							seriesData[key].name=j;

--- a/public/js/realtime/realtimeGraph.js
+++ b/public/js/realtime/realtimeGraph.js
@@ -119,10 +119,8 @@ var RealtimeGraph = function(){
 				}
 				key++;
 			} else if (typeof data.d[j] === 'string') {
-
 				if(!isNaN(data.d[j])) {
-
-					var value = parseInt(data.d[j]);
+					var value = parseFloat(data.d[j]);
 					this.graph.series[key].data.push({x:timestamp,y:value});
 					if (this.graph.series[key].data.length > maxPoints)
 					{
@@ -153,9 +151,8 @@ var RealtimeGraph = function(){
 				seriesData[key].data[0].y = data.d[j];
 				key++;
 			} else if (typeof data.d[j] === 'string') {
-
 				if(!isNaN(data.d[j])) {
-					var value = parseInt(data.d[j]);
+					var value = parseFloat(data.d[j]);
 					seriesData[key]={};
 					seriesData[key].name=j;
 					seriesData[key].color = palette.color();


### PR DESCRIPTION
typo in historianGraph.js breaks graphing for both realtime and historian.  Plus suggest we parseFloat instead.